### PR TITLE
Update upstream versions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ contact: https://github.com/miah0x41
 source-code: https://github.com/miah0x41/ijq-snap
 license: GPL-3.0
 base: core20
-version: "v1.1.2"
+version: "v1.3.0"
 summary: Interactive jq tool - personal package of gpanders/ijq
 description: |
   ijq allows the interactive exploration of JSON utilising jq in the 
@@ -19,12 +19,12 @@ apps:
 parts:
   build-scdoc:
     plugin: make
-    source: https://git.sr.ht/~sircmpwn/scdoc/archive/1.11.3.tar.gz
+    source: https://git.sr.ht/~sircmpwn/scdoc/archive/1.11.4.tar.gz
     build-packages: [gcc]
   build-ijq:
     after: [build-scdoc]
     plugin: make
-    source: https://codeberg.org/gpanders/ijq/archive/v1.1.2.tar.gz
+    source: https://codeberg.org/gpanders/ijq/archive/v1.3.0.tar.gz
     make-parameters:
       - PREFIX=/usr
     build-snaps: [go/latest/stable]


### PR DESCRIPTION
## Upstream Version Updates

- **ijq**: `v1.1.2` → `v1.3.0`
- **scdoc**: `1.11.3` → `1.11.4`

Automated by the Check Upstream Versions workflow.